### PR TITLE
feat: solved 1697 숨바꼭질

### DIFF
--- a/jiyunpar/BFS/1697.cpp
+++ b/jiyunpar/BFS/1697.cpp
@@ -1,0 +1,54 @@
+// 일차원 배열에서 bfs
+#include <iostream>
+#include <utility>
+#include <queue>
+#include <algorithm>
+#include <cstring>
+using namespace std;
+
+int r[3] = {2, 1, 1};
+int m[3] = {0, 1, -1};
+
+int ans[100001];
+int n, k;
+queue<int> Q;
+void get_input(void)
+{
+	memset(ans, -1, sizeof(ans));
+	cin >> n >> k;
+	ans[n] = 0;
+	Q.push(n);
+}
+
+void bfs(void)
+{
+	while (!Q.empty())
+	{
+		int cur = Q.front();
+		Q.pop();
+		for (int i = 0; i < 3; ++i)
+		{
+			int nx = r[i] * cur + m[i];
+			if (nx < 0 || nx >= 100001)
+				continue ;
+			if (ans[nx] != -1)
+				continue ;
+			ans[nx] = ans[cur] + 1;
+			Q.push(nx);
+		}
+	}
+}
+
+int main(void)
+{
+	ios::sync_with_stdio(0);
+	cin.tie(0);
+	get_input();
+	bfs();
+	#ifndef ONLINE_JUDGE
+	for (int i = 0; i < 20; ++i)
+		cout << ans[i] << ' ';
+	#endif
+	cout << ans[k];
+	return (0);
+}


### PR DESCRIPTION
일차원 배열에서의 bfs
최소 시간을 구하기 위해 순간이동하는 경우를 큐에 우선적으로 넣어주는 아이디어를 채택하였음.