### PR TITLE
feat: solved 11729 하노이탑

### DIFF
--- a/jiyunpar/recursive/11729.cpp
+++ b/jiyunpar/recursive/11729.cpp
@@ -1,0 +1,27 @@
+#include <iostream>
+
+using namespace std;
+
+void move_plate(int a, int b, int n)
+{
+	if (n == 1)
+	{
+		cout << a << ' ' << b << '\n';
+		return ;
+	}
+	move_plate(a, 6 - b - a, n - 1);
+	cout << a << ' ' << b << '\n';
+	move_plate(6 - b - a, b, n - 1);
+}
+
+int main(void)
+{
+	ios::sync_with_stdio(0);
+	cin.tie(0);
+
+	int n;
+	cin >> n;
+	cout << (1<<n) - 1 << '\n';
+	move_plate(1, 3, n);
+	return (0);
+}


### PR DESCRIPTION
귀납적 사고 연습 문제
a 에서 b로 n개의 원판을 옮기는 방법

base condition
n = 1일때 a 에서 b로 원판 옮긴다
재귀식
- a에서 빈공간으로 n -1개의 원판 옮긴다.
- a에서 n번째 원판을 b로 옮긴다.
- 빈공간에서 n - 1개의 원판을 b로 옮긴다.

하노이 탑 원판 옮기는 횟수
n + 1개일때 몇번일까?
n개일때 목표 공간(시작위치 ->빈공간)으로 원판 옮기는 횟수가 k번
1개일때 목표 공간으로 옮기는 횟수 1번
n개일때 목표 공간(빈공간-> 마지막위치 )으로 원판 옮기는 횟수가 k번
= 2k+1번
공비가 2인 등비수열이므로 2^k -1