### PR TITLE
feat: solved 2217 로프

### DIFF
--- a/jiyunpar/greedy/2217.cpp
+++ b/jiyunpar/greedy/2217.cpp
@@ -1,0 +1,33 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+
+int main(void)
+{
+	ios::sync_with_stdio(0);
+	cin.tie(0);
+
+	int n;
+	cin >> n;
+	vector<int> seq;
+	seq.reserve(200000);
+	for (int i = 0; i < n; ++i)
+	{
+		int val;
+		cin >> val;
+		seq.push_back(val);
+	}
+	sort(seq.begin(), seq.end());
+	// for (auto i : seq)
+	// 	cout << i;
+	int ans = 0;
+	for (int i = 0; i < n; ++i)
+	{
+		int cur = seq[i] * (n - i);
+		ans = max(ans, cur);
+	}
+	cout << ans;
+	return (0);
+}


### PR DESCRIPTION
vector 사용시 reserve를 사용하자
resize를 사용해서 vector 정렬할 때 문제가 생겼음. 
남은 공간을 다  0 으로 채우는 바람에 이터레이터로 정렬 할때 남는 공간의 0까지 정렬되어 문제 생김